### PR TITLE
chore: improve color accessibility of pytest coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 omit = tests/*
+
+[html]
+extra_css = .coveragerc-html.css

--- a/.coveragerc-html.css
+++ b/.coveragerc-html.css
@@ -1,0 +1,25 @@
+p.mis.show_mis .t {
+    background-color: yellow !important;
+}
+
+p.mis.show_mis .t:hover {
+    background-color: yellow !important;
+}
+
+p.run .t {
+    border-left-color: blue !important
+}
+
+p.mis .t {
+    border-left-color: yellow !important
+}
+
+button.mis.show_mis{
+    background: yellow !important;
+    border-color: yellow !important;
+}
+
+button.run{
+    background: blue !important;
+    color: white !important;
+}


### PR DESCRIPTION
I modified the color scheme of the pytest cov html report from green/red to blue/yellow to improve the color accessibility.
That should make it readable for all of us.

Note: I named the file `.coveragerc` as it seems to be the default name according to the [documentation](https://github.com/nedbat/coveragepy/blob/master/doc/config.rst) and it did not work without the dot. However, it seems like we use a different name in gpyreg. Can change it, but without the dot my pytest cov did not recognize the config,