### PR TITLE
fix: remove deprecated np type aliases

### DIFF
--- a/pyvbmc/stats/kernel_density/kde1d.py
+++ b/pyvbmc/stats/kernel_density/kde1d.py
@@ -26,7 +26,7 @@ def _linear_binning(samples: np.ndarray, grid_points: np.ndarray):
     idx = np.floor((samples - (grid_points[0] - 0.5 * dx)) / dx)
     u, u_counts = np.unique(idx, return_counts=True)
     counts = np.zeros(len(grid_points))
-    counts[u.astype(np.int)] = u_counts
+    counts[u.astype(int)] = u_counts
 
     return counts
 
@@ -91,7 +91,7 @@ def _root(function: callable, N: int, args: tuple):
             x, res = brentq(
                 function, 0, tol, args=args, full_output=True, disp=False
             )
-            converged = np.bool(res.converged)
+            converged = bool(res.converged)
         except ValueError:
             x = 0.0
             tol *= 2.0
@@ -217,7 +217,7 @@ def kde1d(
     # validate values passed to the function
     _validate_kde1d_args(n, lower_bound, upper_bound)
 
-    n = np.int(2 ** np.ceil(np.log2(n)))  # round up to the next power of 2
+    n = int(2 ** np.ceil(np.log2(n)))  # round up to the next power of 2
     if lower_bound is None or upper_bound is None:
         minimum = np.min(samples)
         maximum = np.max(samples)


### PR DESCRIPTION
I replaced `np.int` by `int` and `np.bool` by `bool` as they are deprecated in [numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and are aliases anyways.
This will change now behavior according to numpy, but remove the warnings below.

```
tests/stats/kernel_density/test_kde1d.py: 6 warnings
tests/variational_posterior/test_variational_posterior.py: 10 warnings
  /vbmc/pyvbmc/pyvbmc/stats/kernel_density/kde1d.py:220: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    n = np.int(2 ** np.ceil(np.log2(n)))  # round up to the next power of 2

tests/stats/kernel_density/test_kde1d.py: 6 warnings
tests/variational_posterior/test_variational_posterior.py: 10 warnings
  /vbmc/pyvbmc/pyvbmc/stats/kernel_density/kde1d.py:29: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    counts[u.astype(np.int)] = u_counts

tests/stats/kernel_density/test_kde1d.py: 6 warnings
tests/variational_posterior/test_variational_posterior.py: 10 warnings
  /vbmc/pyvbmc/pyvbmc/stats/kernel_density/kde1d.py:94: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    converged = np.bool(res.converged)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```