### PR TITLE
Remove delta from `VariationalPosterior`

### DIFF
--- a/pyvbmc/acquisition_functions/abstract_acq_fcn.py
+++ b/pyvbmc/acquisition_functions/abstract_acq_fcn.py
@@ -75,21 +75,8 @@ class AbstractAcqFcn(ABC):
 
         # Compute GP posterior predictive mean and variance
 
-        if (
-            hasattr(vp, "delta")
-            and vp.delta is not None
-            and np.any(vp.delta > 0)
-        ):
-            # Quadrature mean and variance for each hyperparameter sample
-            f_mu, f_s2 = gp.quad(
-                mu=Xs,
-                sigma=vp.delta.T,
-                compute_var=True,
-                separate_samples=True,
-            )
-        else:
-            # GP mean and variance for each hyperparameter sample
-            f_mu, f_s2 = gp.predict(x_star=Xs, separate_samples=True)
+        # GP mean and variance for each hyperparameter sample
+        f_mu, f_s2 = gp.predict(x_star=Xs, separate_samples=True)
 
         # Compute total variance
         Ns = f_mu.shape[1]

--- a/pyvbmc/variational_posterior/variational_posterior.py
+++ b/pyvbmc/variational_posterior/variational_posterior.py
@@ -68,8 +68,6 @@ class VariationalPosterior:
     parameter_transformer : ParameterTransformer
         The parameter transformer implementing transformations to/from
         unbounded space.
-    delta : np.ndarray or None (optional)
-        An additional overall scaling factor, of shape ``(1, D)``. Default ``None``.
     bounds : dict
         A dictionary containing the soft bounds for each variable to be
         optimized.
@@ -133,7 +131,6 @@ class VariationalPosterior:
         else:
             self.parameter_transformer = parameter_transformer
 
-        self.delta = None
         self.bounds = None
         self.stats = None
         self._mode = None

--- a/pyvbmc/vbmc/option_configs/advanced_vbmc_options.ini
+++ b/pyvbmc/vbmc/option_configs/advanced_vbmc_options.ini
@@ -243,8 +243,6 @@ upper_gp_length_factor = 0
 init_design = "plausible"
 # Stricter upper bound True GP negative quadratic mean function
 gp_quadratic_mean_bound = True
-# Bandwidth parameter for GP smoothing (in units of plausible box)
-bandwidth = 0
 # Heuristic output warping (fitness shaping)
 fitness_shaping = False
 # Output warping starting threshold

--- a/pyvbmc/vbmc/vbmc.py
+++ b/pyvbmc/vbmc/vbmc.py
@@ -716,10 +716,6 @@ class VBMC:
         optim_state["iter_list"]["f_sd"] = []
         optim_state["iter_list"]["fhyp"] = []
 
-        optim_state["delta"] = self.options.get("bandwidth") * (
-            optim_state.get("pub_tran") - optim_state.get("plb_tran")
-        )
-
         # Deterministic entropy approximation lower/upper factor
         optim_state["entropy_alpha"] = self.options.get("det_entropy_alpha")
 

--- a/tests/acquisition_functions/test_abstract_acquisition_function.py
+++ b/tests/acquisition_functions/test_abstract_acquisition_function.py
@@ -129,53 +129,6 @@ def test__call_constraints(mocker):
     assert np.all(acq == np.inf)
 
 
-def test__call_quad(mocker):
-    """
-    Quadrature mean and variance for each hyperparameter sample by
-    assigning vp.delta = np.ones(1, 2)
-    """
-
-    class BasicAcqClass(AbstractAcqFcn):
-        def _compute_acquisition_function(
-            self,
-            Xs,
-            vp,
-            gp,
-            function_logger,
-            optim_state,
-            f_mu,
-            f_s2,
-            f_bar,
-            var_tot,
-        ):
-            return np.ones(Xs.shape[0])
-
-    M = 1
-
-    Xs = np.ones((M, 3))
-
-    mocker.patch(
-        "gpyreg.GP.quad",
-        return_value=(np.ones((M, 1)), np.zeros((M, 1))),
-    )
-
-    acq_fcn = BasicAcqClass()
-    optim_state = dict()
-    optim_state["integer_vars"] = None
-    optim_state["variance_regularized_acq_fcn"] = False
-    # no constraints for test
-    optim_state["lb_eps_orig"] = -np.inf
-    optim_state["ub_eps_orig"] = np.inf
-    vp = VariationalPosterior(3)
-    # assign delta for test
-    vp.delta = np.ones((1, 2))
-    function_logger = FunctionLogger(lambda x: x, 3, False, 0)
-    acq = acq_fcn(Xs, create_gp(3), vp, function_logger, optim_state)
-
-    assert acq.shape == (M,)
-    assert np.all(acq == 1)
-
-
 def test__call__regularization(mocker):
     """
     Test regularization (penalize points where GP uncertainty is below

--- a/tests/vbmc/test_variational_optimization.py
+++ b/tests/vbmc/test_variational_optimization.py
@@ -263,7 +263,6 @@ def test_vp_optimize_1D_g_mixture():
     vp = VariationalPosterior(D=D, K=2)
     optim_state = dict()
     optim_state["warmup"] = True
-    optim_state["delta"] = np.zeros((1, D))
     optim_state["entropy_switch"] = False
 
     options = setup_options(D, {})
@@ -325,7 +324,6 @@ def test_vp_optimize_2D_g_mixture():
     vp = VariationalPosterior(D=D, K=2)
     optim_state = dict()
     optim_state["warmup"] = True
-    optim_state["delta"] = np.zeros((1, D))
     optim_state["entropy_switch"] = False
 
     options = setup_options(D, {})
@@ -380,7 +378,6 @@ def test_vp_optimize_deterministic_entropy_approximation():
     vp = VariationalPosterior(D=D, K=2)
     optim_state = dict()
     optim_state["warmup"] = True
-    optim_state["delta"] = np.zeros((1, D))
     optim_state["entropy_switch"] = True
 
     options = setup_options(D, {})

--- a/tests/vbmc/test_vbmc_init.py
+++ b/tests/vbmc/test_vbmc_init.py
@@ -621,12 +621,6 @@ def test_vbmc_optimstate_acq_hedge():
     assert "hedge" not in vbmc.optim_state
 
 
-def test_vbmc_optimstate_delta():
-    user_options = {"bandwidth": 1}
-    vbmc = create_vbmc(3, 3, 1, 5, 2, 4, user_options)
-    assert np.all(vbmc.optim_state["delta"] == 1)
-
-
 def test_vbmc_optimstate_entropy_alpha():
     user_options = {"det_entropy_alpha": False}
     vbmc = create_vbmc(3, 3, 1, 5, 2, 4, user_options)


### PR DESCRIPTION
1. Removes unused `vp.delta` attribute, and associated `optim_state["delta"]` key and `bandwidth` option.
    - Appears to be related to smoothing in GP quadrature, but is unused (zero) by default.