### PR TITLE
fix: typo in `vp.mode()`.

### DIFF
--- a/pyvbmc/variational_posterior/variational_posterior.py
+++ b/pyvbmc/variational_posterior/variational_posterior.py
@@ -879,6 +879,8 @@ class VariationalPosterior:
 
             # Evaluate pdf at all points and start optimization from best
             y0_vec = neg_log_pdf(x0_mat)
+            if not orig_flag:  # drop gradient -dy
+                y0_vec = y0_vec[0]
             idx = np.argmin(y0_vec.squeeze())
             x0 = x0_mat[idx]
 
@@ -899,7 +901,10 @@ class VariationalPosterior:
                 )
                 x0 = x0.squeeze()
 
-            res = minimize(fun=neg_log_pdf, x0=x0, bounds=bounds)
+            # fun provides gradient (jac=True) when orig_flag is False:
+            res = minimize(
+                fun=neg_log_pdf, x0=x0, bounds=bounds, jac=not orig_flag
+            )
             x_min[k] = res.x
             ff[k] = res.fun
 


### PR DESCRIPTION
Not sure if anyone else had this issue, but for me this fixes `test_mode_no_orig()`, which was failing because it unexpectedly provided a gradient to `scipy.minimize`. Now `vp.mode()` tells `minimize` that the objective is also returning the gradient as a second argument, when `orig_flag=False`.