### PR TITLE
fix: `IndexError` due to Numpy issue #21840.

### DIFF
--- a/pyvbmc/vbmc/active_sample.py
+++ b/pyvbmc/vbmc/active_sample.py
@@ -152,10 +152,10 @@ def active_sample(
 
         # Remove points from starting cache
         optim_state["cache"]["x_orig"] = np.delete(
-            optim_state["cache"]["x_orig"], idx_remove, 0
+            optim_state["cache"]["x_orig"], np.where(idx_remove), 0
         )
         optim_state["cache"]["y_orig"] = np.delete(
-            optim_state["cache"]["y_orig"], idx_remove, 0
+            optim_state["cache"]["y_orig"], np.where(idx_remove), 0
         )
 
         Xs = parameter_transformer(Xs)


### PR DESCRIPTION
1. Fixes an `IndexError` arising in `active_sample.py` in Numpy>=1.23, caused by Numpy [issue #21840](https://github.com/numpy/numpy/issues/21840).
    a. In Numpy>=1.23, `np.delete` interprets length-1 boolean arrays as integer indices, instead of masks. To fix, `active_sample.py` now casts the relevant boolean masks to indices explicitly.