### PR TITLE
docs: add note re: `UnsatisfiableError` in Python 3.11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ PyVBMC is available via `pip` and `conda-forge`.
    ```console
    conda install jupyter
    ```
-   The example notebooks can be accessed by running
+   If you are running Python 3.11 and get an `UnsatisfiableError` you may need to install Jupyter from `conda-forge`:
+   ```console
+   conda install --channel=conda-forge jupyter
+   ```
+   The example notebooks can then be accessed by running
    ```console
    python -m pyvbmc
    ```

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -18,6 +18,10 @@ PyVBMC is available via ``pip`` and ``conda-forge``.
 
      conda install jupyter
 
+   If you are running Python 3.11 and get an ``UnsatisfiableError`` you may need to install Jupyter from ``conda-forge``::
+
+     conda install --channel=conda-forge jupyter
+
    The example notebooks can be accessed by running ::
 
      python -m pyvbmc


### PR DESCRIPTION
Suggest using `--channel=conda-forge` to install Jupyter, if encountering `UnsatisfiableError` in Python 3.11.