### PR TITLE
fix: eliminate log warning by setting KL divergences to inf.

### DIFF
--- a/pyvbmc/stats/kl_div_mvn.py
+++ b/pyvbmc/stats/kl_div_mvn.py
@@ -34,6 +34,9 @@ def kl_div_mvn(mu1, sigma1, mu2, sigma2):
     dmu = mu2 - mu1
     detq1 = np.linalg.det(sigma1)
     detq2 = np.linalg.det(sigma2)
+    if (detq1 == 0 or detq2 == 0):
+        # KL divergence is infinite
+        return np.concatenate((np.inf, np.inf), axis=None)
     lndet = np.log(detq2 / detq1)
     a, _, _, _ = np.linalg.lstsq(sigma2, sigma1, rcond=None)
     b, _, _, _ = np.linalg.lstsq(sigma2, dmu, rcond=None)

--- a/pyvbmc/vbmc/vbmc.py
+++ b/pyvbmc/vbmc/vbmc.py
@@ -1185,7 +1185,7 @@ class VBMC:
             timer.start_timer("finalize")
 
             # Compute symmetrized KL-divergence between old and new posteriors
-            Nkl = 1e5
+            Nkl = int(1e5)
 
             sKL = max(
                 0,


### PR DESCRIPTION
When computing KL divergences between two multivariate Gaussians, there are warnings if one of them has zero determinant. The warning(actually it's also a minor bug since one of the KL divergences would be evaluated as `-inf` and later truncated to 0) is eliminated by directly returning KL divergences as `np.inf` in that special case.


