### PR TITLE
refactor: clarify `VBMC._check_termination_conditions()`.

### DIFF
--- a/pyvbmc/testing/vbmc/test_vbmc_loop_termination.py
+++ b/pyvbmc/testing/vbmc/test_vbmc_loop_termination.py
@@ -39,10 +39,10 @@ def test_vbmc_check_termination_conditions_max_fun_evals(mocker):
         "_compute_reliability_index",
         return_value=(np.Inf, np.NaN),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert terminated
     vbmc.function_logger.func_count = 9
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
 
@@ -62,10 +62,10 @@ def test_vbmc_check_termination_conditions_max_iter(mocker):
         "_compute_reliability_index",
         return_value=(np.Inf, np.NaN),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert terminated
     vbmc.optim_state["iter"] = 98
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
 
@@ -85,7 +85,7 @@ def test_vbmc_check_termination_conditions_prevent_early_termination(mocker):
         "_compute_reliability_index",
         return_value=(np.Inf, np.NaN),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
     options = {
@@ -103,7 +103,7 @@ def test_vbmc_check_termination_conditions_prevent_early_termination(mocker):
         "_compute_reliability_index",
         return_value=(np.Inf, np.NaN),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
 
@@ -129,14 +129,14 @@ def test_vbmc_check_termination_conditions_stability(mocker):
         "_compute_reliability_index",
         return_value=(0.5, 0.005),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert terminated
     mocker.patch.object(
         vbmc,
         "_compute_reliability_index",
         return_value=(1, 0.005),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
     mocker.patch.object(
@@ -144,7 +144,7 @@ def test_vbmc_check_termination_conditions_stability(mocker):
         "_compute_reliability_index",
         return_value=(0.5, 0.1),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
     vbmc.optim_state["iter"] = 9
@@ -153,7 +153,7 @@ def test_vbmc_check_termination_conditions_stability(mocker):
         "_compute_reliability_index",
         return_value=(1, 0.005),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
 
@@ -177,7 +177,7 @@ def test_vbmc_is_finished_stability_entropy_switch(mocker):
         "_compute_reliability_index",
         return_value=(0.5, 0.005),
     )
-    terminated, _, _ = vbmc._check_termination_conditions()
+    terminated, __ = vbmc._check_termination_conditions()
     assert not terminated
 
 

--- a/pyvbmc/testing/vbmc/test_vbmc_optimize.py
+++ b/pyvbmc/testing/vbmc/test_vbmc_optimize.py
@@ -486,7 +486,7 @@ def test_optimize_results(mocker):
     mocker.patch.object(
         vbmc,
         "_check_termination_conditions",
-        return_value=(True, "test message", True),
+        return_value=(True, "test message"),
     )
     mocker.patch(
         "pyvbmc.vbmc.vbmc.optimize_vp", return_value=(vbmc.vp, None, None)


### PR DESCRIPTION
1. Adds a heuristic to avoid exiting after a recent warping to `VBMC._check_termination_conditions()` (same check as exists in MATLAB version, but it wasn't present in Python).
2. Removes the assignment of `success_flag` from  `VBMC._check_termination_condition()`, since the flag is reset based on VP stability at the end of the VBMC main loop.