### PR TITLE
Minor fixes from JoSS review + static linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         exclude: ^docs/
@@ -8,16 +8,16 @@ repos:
         exclude_types: [json, binary]
         exclude: ^docs/
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
         additional_dependencies: [toml]
         exclude: docs/tutorials
   - repo: https://github.com/psf/black
-    rev: "22.3.0"
+    rev: "23.3.0"
     hooks:
       - id: black-jupyter
   - repo: https://github.com/hadialqattan/pycln
-    rev: "v1.2.5"
+    rev: "v2.1.3"
     hooks:
       - id: pycln

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ vbmc = VBMC(target, x0, LB, UB, PLB, PUB)
 vp, results = vbmc.optimize()
 ```
 with input arguments:
-- `target`: the target (unnormalized) log density — often an unnormalized log posterior. `target` is a callable that should take as input a parameter vector and return the log density at the point;
+- `target`: the target (unnormalized) log density — often an unnormalized log posterior. `target` is a callable that should take as input a parameter vector and return the log density at the point. The returned log density must return a *finite* real value, i.e. non `NaN` or `-inf`. See the [VBMC FAQ](https://github.com/acerbilab/vbmc/wiki#how-do-i-prevent-vbmc-from-evaluating-certain-inputs-or-regions-of-input-space) for more details;
 - `x0`: an array representing the starting point of the inference in parameter space;
 - `LB` and `UB`: arrays of hard lower (resp. upper) bounds constraining the parameters (possibly `-/+np.inf` for unbounded parameters);
 - `PLB` and `PUB`: arrays of plausible lower (resp. upper) bounds: that is, a box that ideally brackets a high posterior density region of the target.

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -26,4 +26,10 @@ PyVBMC is available via ``pip`` and ``conda-forge``.
 
      python -m pyvbmc
 
+You can run PyVBMC's internal tests with ::
+
+  pytest --pyargs pyvbmc --reruns=3
+
+The `--reruns=3` argument allows re-trying a failed test up to 3 times, as many of PyVBMC's tests are stochastic in nature. Note that the complete test suite may take a significant amount of time (20-30 minutes or more, depending on your hardware).
+
 If you wish to install directly from latest source code, please see the :ref:`installation instructions for developers`.

--- a/docsrc/source/quickstart.rst
+++ b/docsrc/source/quickstart.rst
@@ -29,7 +29,7 @@ Running the inference in step 3 only involves a couple of lines of code:
 
 with input arguments:
 
-- ``target``: the target (unnormalized) log density — often an unnormalized log posterior. ``target`` takes as input a parameter vector and returns the log density at the point;
+- ``target``: the target (unnormalized) log density — often an unnormalized log posterior. ``target`` takes as input a parameter vector and returns the log density at the point. The returned log density must return a *finite* real value, i.e. non `NaN` or `-inf`. See the :labrepos:`VBMC FAQ <vbmc/wiki#how-do-i-prevent-vbmc-from-evaluating-certain-inputs-or-regions-of-input-space>` for more details;
 - ``x0``: the starting point of the inference in parameter space;
 - ``LB`` and ``UB``: hard lower and upper bounds for the parameters (can be ``-inf`` and ``inf``, or bounded);
 - ``PLB`` and ``PUB``: *plausible* lower and upper bounds, that is a box that ideally brackets a region of high density of the target.

--- a/pyvbmc/function_logger/function_logger.py
+++ b/pyvbmc/function_logger/function_logger.py
@@ -145,7 +145,7 @@ class FunctionLogger:
             f_val_orig = np.array(f_val_orig).flat[0]
 
         # Check function value
-        if np.any(
+        if (
             not np.isscalar(f_val_orig)
             or not np.isfinite(f_val_orig)
             or not np.isreal(f_val_orig)

--- a/pyvbmc/vbmc/active_sample.py
+++ b/pyvbmc/vbmc/active_sample.py
@@ -7,6 +7,7 @@ import gpyreg as gpr
 import numpy as np
 
 from pyvbmc.acquisition_functions import AbstractAcqFcn
+from pyvbmc.acquisition_functions.utilities import string_to_acq
 from pyvbmc.function_logger import FunctionLogger
 from pyvbmc.stats import get_hpd
 from pyvbmc.timer import main_timer as timer
@@ -271,7 +272,6 @@ def active_sample(
             noise_N = gp.noise.hyperparameter_count()
 
             for s in range(Ns_gp):
-
                 hyp_noise = gp.posteriors[s].hyp[cov_N : cov_N + noise_N]
                 if hasattr(function_logger, "S"):
                     s2 = (
@@ -380,7 +380,6 @@ def active_sample(
                     tol_fun = max(1e-12, abs(f_val_old * 1e-3))
 
                 if options["search_optimizer"] == "cmaes":
-
                     if options["search_cmaes_vp_init"]:
                         _, Sigma = vp.moments(orig_flag=False, cov_flag=True)
                     else:

--- a/pyvbmc/vbmc/option_configs/advanced_vbmc_options.ini
+++ b/pyvbmc/vbmc/option_configs/advanced_vbmc_options.ini
@@ -7,8 +7,6 @@ integer_vars = []
 noise_size = []
 # Max number of consecutive repeated measurements for noisy inputs
 max_repeated_observations = 0
-# Multiplicative discount True acquisition fcn to repeat measurement at the same location
-repeated_acq_discount = 1
 # Number of initial target fcn evals
 fun_eval_start = np.maximum(D, 10)
 # Base step size for stochastic gradient descent
@@ -33,8 +31,6 @@ output_fcn = []
 tol_stable_excpt_frac = 0.2
 # Evaluated fcn values at X0
 f_vals = []
-# Use Optimization Toolbox (if empty determine at runtime)
-optim_toolbox = []
 # Weighted proposal fcn for uncertainty search
 proposal_fcn = None
 # Automatic nonlinear rescaling of variables

--- a/pyvbmc/vbmc/option_configs/basic_vbmc_options.ini
+++ b/pyvbmc/vbmc/option_configs/basic_vbmc_options.ini
@@ -11,8 +11,6 @@ max_fun_evals = 50*(2+D)
 fun_evals_per_iter = 5
 # Required stable fcn evals for termination
 tol_stable_count = 60
-# Max number of target fcn evals on retry (0 = no retry)
-retry_max_fun_evals = 0
 # Number of variational components to refine posterior at termination
 min_final_components = 50
 # Target log joint function returns noise estimate (SD) as second output

--- a/pyvbmc/vbmc/vbmc.py
+++ b/pyvbmc/vbmc/vbmc.py
@@ -48,7 +48,7 @@ class VBMC:
         the target log-joint, that is, the unnormalized log-posterior density
         at ``x``. If ``log_prior`` is not ``None``, ``log_density`` should
         return the unnormalized log-likelihood. In either case, if
-        ``options["specifytargetnoise"]`` is true, ``log_density`` should
+        ``options["specify_target_noise"]`` is true, ``log_density`` should
         return a tuple where the first element is the noisy log-density, and
         the second is an estimate of the standard deviation of the noise.
     x0 : np.ndarray, optional
@@ -110,11 +110,6 @@ class VBMC:
         `plausible_upper_bounds`) are specified.
     ValueError
         When various checks for the bounds (LB, UB, PLB, PUB) of VBMC fail.
-
-    Notes
-    -----
-    The current version of ``VBMC`` only supports noiseless evaluations of the
-    log posterior [1]_. Noisy evaluations as in [2]_ are not implemented yet.
 
     References
     ----------


### PR DESCRIPTION
1. Adds notes to the documentation regarding: `pytest --reruns=x`, and non-finite values in the target function.
2. Removes unused options keywords.
3. Other minor documentation fixes.
4. Other minor static linting fixes (thanks, @pipme).